### PR TITLE
update all yml

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -68,7 +68,7 @@ nginx_enable_default_server: false
 nginx_conf_http:
   client_max_body_size: 1g
 
-nginx_ssl_role: self-signed-cert
+nginx_ssl_role: galaxyproject.self_signed_certs
 nginx_conf_ssl_certificate: /etc/ssl/certs/ansible.com.crt
 nginx_conf_ssl_certificate_key: /etc/ssl/private/ansible.com.pem
 


### PR DESCRIPTION
I installed the new roles.
Should self-signed-certs not be changed into galaxyproject.self_signed_certs?

because of :

TASK [Include SSL role] ********************************************************
ERROR! the role 'self-signed-cert' was not found in /var/lib/jenkins/workspace/galaxy/roles:/var/lib/jenkins/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/var/lib/jenkins/workspace/galaxy