### PR TITLE
adding to proxypass

### DIFF
--- a/host_vars/galaxy.bioinformatics-atgm.nl/all.yml
+++ b/host_vars/galaxy.bioinformatics-atgm.nl/all.yml
@@ -1,14 +1,14 @@
-project_directory: /mount/sdb
+project_directory: /mnt/studentfiles
 machine_shortname: Isengard
 
 backup_host: asgard.bioinformatics-atgm.nl
-backup_location: /mnt/TeacherFiles/project_backup
+backup_location: /mnt/backup
 backup_max_size: 1000
 
 directories_to_monitor_size:
-- path: /mount/sdb
-  max_size: 5632
-- path: /mount/sda
-  max_size: 5632
-- path: /mount/sdb/project_backup
-  max_size: 5632
+- path: /mnt/studentfiles
+  max_size: 5500
+- path: /mnt/teacherfiles
+  max_size: 3400
+- path: /mnt/backup
+  max_size: 1300

--- a/hosts
+++ b/hosts
@@ -3,7 +3,7 @@
 #####################
 [avans]
 midgard.bioinformatics-atgm.nl ansible_user=artemis
-galaxy.bioinformatics-atgm.nl ansible_user=bioinf_team
+galaxy.bioinformatics-atgm.nl ansible_user=atgm-user
 asgard.bioinformatics-atgm.nl ansible_user=thor
 7kingdoms.bioinformatics-atgm.nl ansible_user=godzilla
 

--- a/templates/nginx/galaxy.j2
+++ b/templates/nginx/galaxy.j2
@@ -68,6 +68,7 @@ server {
 	location /grafana/ {
 		proxy_buffering off;
 		proxy_pass          http://127.0.0.1:3000/;
+		proxy_set_header Host $http_host;
 	}
 
 	# For GTN in Galaxy Webhook


### PR DESCRIPTION
Hi @hexylena 

Lately is there an error in Grafana, which does me only allow to login after i delete all cookies and als do not allow me to modify anything in grafana:

``` Origin not allowed ``` in the logs is the following stated:

```
Feb 14 08:42:41 galaxy.atgm.avans.nl grafana-server[2620858]: t=2022-02-14T08:42:41+0000 lvl=eror msg="Organiza                                                                                                                        tion not found" logger=context userId=1 orgId=1 uname=admin error="organization not found" remote_addr=127.0.0.                                                                                                                        1
```

So appearntly this is a common bug in our version of grafana which is easy to solve according other people.

https://github.com/grafana/grafana/issues/45117#issuecomment-1033842787
https://community.grafana.com/t/after-update-to-8-3-5-origin-not-allowed-behind-proxy/60598
